### PR TITLE
Remove chooseXAxis by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ If the xAxis displays a timestamp the format of if can be defined by passing a S
 Sample: `function (x) { return x.getFullYear(); }`
 
 ---
+##### xAxisSelector : boolean
+Shows the dropdown to choose which xAxis you want to use. Default: `false`
+
+---
+
 #### subchart : Object
 Defines the subchart.
 

--- a/angular-chart.js
+++ b/angular-chart.js
@@ -169,7 +169,7 @@ angular.module('angularChart', [])
           // Choose x-axis
           //
           scope.chooseXAxis = function () {
-            if (scope.options.type === 'pie' || scope.options.type === 'donut') {
+            if (scope.options.type === 'pie' || scope.options.type === 'donut' || !scope.options.xAxisSelector) {
               return;
             }
             var el = angular.element('<span/>');

--- a/test/angular-chart_spec.js
+++ b/test/angular-chart_spec.js
@@ -204,6 +204,22 @@ describe('angularChart', function () {
       expect(element.html()).not.toBe(null);
     });
 
+    it('Creating a chart without xAxis by default', function () {
+      scope.options.type = 'line';
+      scope.options.xAxis.name = 'sales';
+      scope.$apply();
+      expect(element.html()).not.toContain('</span>');
+    });
+
+    it('Creating a chart with xAxis selector', function () {
+      scope.options.type = 'line';
+      scope.options.xAxis.name = 'sales';
+      scope.options.xAxisSelector = true;
+      scope.$apply();
+
+      expect(element.html()).toContain('</span>');
+    });
+
     it('Creating a line chart with subchart', function () {
       scope.options.subchart = {
         show: true


### PR DESCRIPTION
By default, C3.js does not provide the dropdown which allows to choose the xAxis. In order to match that behavior, I propose to move it into an option. Tell me what you think!
