### PR TITLE
WIP - Fixes #12 Tooltip is displayed far too below when using <angularchart> as an element

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -52,6 +52,15 @@ angular.module('angularChart', [])
             }
           };
 
+          // replace the <angularchart> directive to a <div> in order to avoid issue #12
+          //
+          scope.replaceDirectiveToDiv = function() {
+            var dom = angular.element('<div/>');
+            var e = $compile(dom)(scope);
+            element.replaceWith(e); // Make changes into the DOM
+            element = e;            // Change the reference of the element for the other functions
+          };
+
           // add unique identifier for each chart
           //
           scope.addIdentifier = function () {
@@ -303,6 +312,7 @@ angular.module('angularChart', [])
 
 
           // startup
+          scope.replaceDirectiveToDiv();
           scope.addIdentifier();
           scope.updateChart();
 


### PR DESCRIPTION
This commit makes all the unit tests using scope.getElementScope() failing.
I don't see a way to fix them right now. Do you have any idea @maxklenk?

Thanks!
