### PR TITLE
Support for strict dependency injection and CommonJs loading

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -1,7 +1,8 @@
-'use strict';
+(function(){
+  'use strict';
 
-angular.module('angularChart', [])
-  .directive('angularchart',
+var angularChart = angular.module('angularChart', [])
+  .directive('angularchart', ['$compile', 
 
     function ($compile) {
 
@@ -705,7 +706,12 @@ angular.module('angularChart', [])
           scope.selections.performSelections(scope.options.selection.selected);
           scope.startOptionsWatcher();
           scope.startDatasetWatcher();
-
+          
         }
       };
-    });
+    }]);
+    
+    if ('undefined' !== typeof exports && 'undefined' !== typeof module) {
+        module.exports = angularChart;
+    }
+})();


### PR DESCRIPTION
I added suppport for Strict Dependency injection and also exported the module in order to do things like

``` javascript
angular.module('foo', [require('angular-chart').name]);
```

Indentation could be wrong as I edited directly from GitHub.
