### PR TITLE
Expose the "resize()" function of c3 to angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ Pie-, Donut chart: _(Currently adding a selection in the Array will not add the 
 Triggered when you click on a data point.
 Sample: `function(d, element) { console.log('Point at', d.x, 'of the serie', d.name 'has been clicked; corresponding htmlElement:', element) };`
 
+##### resize : function
+Call this function to trigger the c3 resize() function (http://c3js.org/samples/api_resize.html)
+
 ---
 
 ## Development [![Stories in Ready](https://badge.waffle.io/maxklenk/angular-chart.png?label=ready&title=Ready)](https://waffle.io/maxklenk/angular-chart) [![Gitter chat](https://badges.gitter.im/maxklenk/angular-chart.png)](https://gitter.im/maxklenk/angular-chart)

--- a/angular-chart.js
+++ b/angular-chart.js
@@ -496,6 +496,16 @@
               scope.options.rows[options.index].show = clicked.show;
             };
 
+            // expose resize function of c3 to outside
+            //
+            if(scope.options.resize){
+              scope.options.resize = function() {
+                scope.chart.resize();
+              };
+            }else{
+              scope.options.resize = angular.noop;
+            }
+
             // generate circular options
             //
             scope.rowEdit = [];
@@ -652,19 +662,19 @@
                 return isOld;
               });
 
-            //do actual removal /adding of selections and return if something happened.
-            var didSomething = false;
-            if (addedSelections.length > 0) {
+              //do actual removal /adding of selections and return if something happened.
+              var didSomething = false;
+              if (addedSelections.length > 0) {
                 this.performSelections(addedSelections);
                 didSomething = true;
-            }
+              }
 
-            if (removedSelections.length > 0) {
+              if (removedSelections.length > 0) {
                 this.performUnselections(removedSelections);
                 didSomething = true;
-            }
+              }
 
-            return didSomething;
+              return didSomething;
             }
           };
 


### PR DESCRIPTION
Hi Max, 

I'd like to expose the resize() function from c3; I need to call it when resizing the div which contains the chart but not resizing the window itself. 

Unfortunately, I could not figure out how to test this functionality. I don't know how to get the "chart" property of the directive in the test. If I could, I would maybe test it like this:

```
  describe('. resize', function () {
    it('- Resize on chart should be callable from outside.', function () {

      directiveScope.chart = {resize: angular.noop};
      spyOn(directiveScope.chart, 'resize');
      elementScope.options.resize();

      expect(directiveScope.chart.resize()).toHaveBeenCalled();

    });
  });
```

Where directiveScope is the scope of the Directive and elementScope is the scope of outside. 
