### PR TITLE
Exposed the "resize()" function of c3 to outside.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ Pie-, Donut chart: _(Currently adding a selection in the Array will not add the 
 Triggered when you click on a data point.
 Sample: `function(d, element) { console.log('Point at', d.x, 'of the serie', d.name 'has been clicked; corresponding htmlElement:', element) };`
 
+##### resize : function
+Call this function to trigger the c3 resize() function (http://c3js.org/samples/api_resize.html)
+
 ---
 
 ## Development [![Stories in Ready](https://badge.waffle.io/maxklenk/angular-chart.png?label=ready&title=Ready)](https://waffle.io/maxklenk/angular-chart) [![Gitter chat](https://badges.gitter.im/maxklenk/angular-chart.png)](https://gitter.im/maxklenk/angular-chart)

--- a/angular-chart.js
+++ b/angular-chart.js
@@ -574,7 +574,14 @@
 
           };
 
-          // Selections
+	        // expose resize function of c3 to outside
+	        //
+	        scope.options.resize = function () {
+		        scope.chart.resize();
+	        };
+
+
+	        // Selections
           //
           scope.selections = {
             avoidSelections: false,


### PR DESCRIPTION
Hi Max,

I'd like to expose the resize() function from c3; I need to call it when resizing the div which contains the chart but not resizing the window itself.

Unfortunately, I could not figure out how to test this functionality. I don't know how to get the "chart" property of the directive in the test. If I could, I would maybe test it like this:

  describe('. resize', function () {
    it('- Resize on chart should be callable from outside.', function () {

```
  directiveScope.chart = {resize: angular.noop};
  spyOn(directiveScope.chart, 'resize');
  elementScope.options.resize();

  expect(directiveScope.chart.resize()).toHaveBeenCalled();

});
```

  });
Where directiveScope is the scope of the directive and elementScope is the scope of outside.

Something else: Unfortunately, it seems that indentation of my changes are not correct. Can you tell me, how to use your project style in Webstorm/PHPStorm? 
