### PR TITLE
adding version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angular-chart",
+  "version": "0.3.3",
   "description": "C3-based reusable chart directive",
   "main": "angular-chart.js",
   "scripts": {


### PR DESCRIPTION
was getting some complaints from yarn install after moving off of bower -- seems version is now required, so I added it to match the bower version.